### PR TITLE
Logger and log levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to **RTVI Client Web** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.2] - 2024-11-12
+
+### Added
+
+- `setLogLevel` method added to `RTVIClient` to allow developers to set the log level.
+- `logger` instance added to `RTVIClient` to allow developers to set the log level.
+
 ## [0.2.1] - 2024-10-28
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "rtvi-client-web",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "workspaces": [
     "rtvi-sandbox",
     "rtvi-client-js",

--- a/rtvi-client-js/package.json
+++ b/rtvi-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realtime-ai",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
   "module": "dist/index.module.js",

--- a/rtvi-client-js/src/actions.ts
+++ b/rtvi-client-js/src/actions.ts
@@ -1,4 +1,4 @@
-import { RTVIClientParams, RTVIError } from ".";
+import { logger, RTVIClientParams, RTVIError } from ".";
 import { RTVIActionRequest, RTVIActionResponse } from "./messages";
 
 export async function httpActionGenerator(
@@ -8,7 +8,7 @@ export async function httpActionGenerator(
   handleResponse: (response: RTVIActionResponse) => void
 ): Promise<void> {
   try {
-    console.debug("[RTVI] Fetch action", actionUrl, action);
+    logger.debug("[RTVI] Fetch action", actionUrl, action);
 
     const headers = new Headers({
       ...Object.fromEntries((params.headers ?? new Headers()).entries()),
@@ -73,7 +73,7 @@ export async function httpActionGenerator(
             const parsedData = JSON.parse(jsonData);
             handleResponse(parsedData);
           } catch (error) {
-            console.error("[RTVI] Failed to parse JSON:", error);
+            logger.error("[RTVI] Failed to parse JSON:", error);
             throw error;
           }
 
@@ -86,7 +86,7 @@ export async function httpActionGenerator(
       handleResponse(data);
     }
   } catch (error) {
-    console.error("[RTVI] Error during fetch:", error);
+    logger.error("[RTVI] Error during fetch:", error);
     throw error;
   }
 }

--- a/rtvi-client-js/src/client.ts
+++ b/rtvi-client-js/src/client.ts
@@ -7,6 +7,7 @@ import { getIfTransportInState, transportReady } from "./decorators";
 import * as RTVIErrors from "./errors";
 import { RTVIEvent, RTVIEvents } from "./events";
 import { RTVIClientHelper, RTVIClientHelpers } from "./helpers";
+import { logger, LogLevel } from "./logger";
 import {
   BotLLMTextData,
   BotReadyData,
@@ -376,7 +377,7 @@ export class RTVIClient extends RTVIEventEmitter {
     this._initialize();
 
     // Get package version number
-    console.debug("[RTVI Client] Initialized", this.version);
+    logger.debug("[RTVI Client] Initialized", this.version);
   }
 
   public constructUrl(endpoint: RTVIURLEndpoints): string {
@@ -388,13 +389,18 @@ export class RTVIClient extends RTVIEventEmitter {
     const baseUrl = this.params.baseUrl.replace(/\/+$/, "");
     return baseUrl + (this.params.endpoints?.[endpoint] ?? "");
   }
+
+  public setLogLevel(level: LogLevel) {
+    logger.setLevel(level);
+  }
+
   // ------ Transport methods
 
   /**
    * Initialize local media devices
    */
   public async initDevices() {
-    console.debug("[RTVI Client] Initializing devices...");
+    logger.debug("[RTVI Client] Initializing devices...");
     await this._transport.initDevices();
   }
 
@@ -448,8 +454,8 @@ export class RTVIClient extends RTVIEventEmitter {
           },
         };
 
-        console.debug("[RTVI Client] Connecting...", connectUrl);
-        console.debug("[RTVI Client] Start params", this.params);
+        logger.debug("[RTVI Client] Connecting...", connectUrl);
+        logger.debug("[RTVI Client] Start params", this.params);
 
         try {
           if (customConnectHandler) {
@@ -506,7 +512,7 @@ export class RTVIClient extends RTVIEventEmitter {
           return;
         }
 
-        console.debug("[RTVI Client] Auth bundle received", authBundle);
+        logger.debug("[RTVI Client] Auth bundle received", authBundle);
 
         try {
           await this._transport.connect(
@@ -635,7 +641,7 @@ export class RTVIClient extends RTVIEventEmitter {
     config: RTVIClientConfigOption[],
     interrupt: boolean = false
   ): Promise<RTVIMessage> {
-    console.debug("[RTVI Client] Updating config", config);
+    logger.debug("[RTVI Client] Updating config", config);
     // Only send the partial config if the bot is ready to prevent
     // potential racing conditions whilst pipeline is instantiating
     return this._messageDispatcher.dispatch(
@@ -671,7 +677,7 @@ export class RTVIClient extends RTVIEventEmitter {
     return Promise.resolve().then(async () => {
       // Check if we have registered service with name service
       if (!serviceKey) {
-        console.debug("Target service name is required");
+        logger.debug("Target service name is required");
         return undefined;
       }
 
@@ -684,7 +690,7 @@ export class RTVIClient extends RTVIEventEmitter {
       );
 
       if (!configServiceKey) {
-        console.debug(
+        logger.debug(
           "No service with name " + serviceKey + " not found in config"
         );
         return undefined;
@@ -710,7 +716,7 @@ export class RTVIClient extends RTVIEventEmitter {
       await this.getServiceOptionsFromConfig(serviceKey, config);
 
     if (!configServiceKey) {
-      console.debug("Service with name " + serviceKey + " not found in config");
+      logger.debug("Service with name " + serviceKey + " not found in config");
       return undefined;
     }
 
@@ -768,7 +774,7 @@ export class RTVIClient extends RTVIEventEmitter {
     );
 
     if (!serviceOptions) {
-      console.debug(
+      logger.debug(
         "Service with name '" + serviceKey + "' not found in config"
       );
       return newConfig;
@@ -865,7 +871,7 @@ export class RTVIClient extends RTVIEventEmitter {
   }
 
   protected handleMessage(ev: RTVIMessage): void {
-    console.debug("[RTVI Message]", ev);
+    logger.debug("[RTVI Message]", ev);
 
     switch (ev.type) {
       case RTVIMessageType.BOT_READY:
@@ -1001,7 +1007,7 @@ export class RTVIClient extends RTVIEventEmitter {
   public getHelper<T extends RTVIClientHelper>(service: string): T | undefined {
     const helper = this._helpers[service];
     if (!helper) {
-      console.debug(`Helper targeting service '${service}' not found`);
+      logger.debug(`Helper targeting service '${service}' not found`);
       return undefined;
     }
     return helper as T;
@@ -1029,7 +1035,7 @@ export class RTVIClient extends RTVIEventEmitter {
    */
   @transportReady
   public async getBotConfig(): Promise<RTVIClientConfigOption[]> {
-    console.warn(
+    logger.warn(
       "VoiceClient.getBotConfig is deprecated. Use getConfig instead."
     );
     return this.getConfig();
@@ -1042,7 +1048,7 @@ export class RTVIClient extends RTVIEventEmitter {
    * @returns RTVIClientConfigOption[] - Array of configuration options
    */
   public get config(): RTVIClientConfigOption[] {
-    console.warn("VoiceClient.config is deprecated. Use getConfig instead.");
+    logger.warn("VoiceClient.config is deprecated. Use getConfig instead.");
     return this._options.config!;
   }
 
@@ -1051,7 +1057,7 @@ export class RTVIClient extends RTVIEventEmitter {
    * @deprecated Services not accessible via the client instance
    */
   public get services(): VoiceClientServices {
-    console.warn("VoiceClient.services is deprecated.");
+    logger.warn("VoiceClient.services is deprecated.");
     return this._options.services!;
   }
 
@@ -1059,7 +1065,7 @@ export class RTVIClient extends RTVIEventEmitter {
    * @deprecated Services not accessible via the client instance
    */
   public set services(services: VoiceClientServices) {
-    console.warn("VoiceClient.services is deprecated.");
+    logger.warn("VoiceClient.services is deprecated.");
     if (
       !["authenticating", "connecting", "connected", "ready"].includes(
         this._transport.state

--- a/rtvi-client-js/src/index.ts
+++ b/rtvi-client-js/src/index.ts
@@ -4,5 +4,6 @@ export * from "./errors";
 export * from "./events";
 export * from "./helpers";
 export * from "./helpers/llm";
+export * from "./logger";
 export * from "./messages";
 export * from "./transport";

--- a/rtvi-client-js/src/logger.ts
+++ b/rtvi-client-js/src/logger.ts
@@ -1,0 +1,53 @@
+export enum LogLevel {
+  NONE = 0,
+  ERROR = 1,
+  WARN = 2,
+  INFO = 3,
+  DEBUG = 4,
+}
+
+class Logger {
+  private static instance: Logger;
+  private level: LogLevel = LogLevel.DEBUG;
+
+  private constructor() {}
+
+  static getInstance(): Logger {
+    if (!Logger.instance) {
+      Logger.instance = new Logger();
+    }
+    return Logger.instance;
+  }
+
+  setLevel(level: LogLevel) {
+    this.level = level;
+  }
+
+  debug(...args: unknown[]) {
+    if (this.level >= LogLevel.DEBUG) {
+      console.debug(...args);
+    }
+  }
+
+  info(...args: unknown[]) {
+    if (this.level >= LogLevel.INFO) {
+      console.info(...args);
+    }
+  }
+
+  warn(...args: unknown[]) {
+    if (this.level >= LogLevel.WARN) {
+      console.warn(...args);
+    }
+  }
+
+  error(...args: unknown[]) {
+    if (this.level >= LogLevel.ERROR) {
+      console.error(...args);
+    }
+  }
+}
+
+export const logger = Logger.getInstance();
+
+export type ILogger = Logger;

--- a/rtvi-client-js/src/messages.ts
+++ b/rtvi-client-js/src/messages.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { httpActionGenerator } from "./actions";
 import { RTVIClient, RTVIClientConfigOption } from "./client";
+import { logger } from "./logger";
 
 export const RTVI_MESSAGE_LABEL = "rtvi-ai";
 
@@ -185,7 +186,7 @@ export class MessageDispatcher {
       });
     });
 
-    console.debug("[MessageDispatcher] dispatch", message);
+    logger.debug("[MessageDispatcher] dispatch", message);
 
     this._client.sendMessage(message);
 
@@ -207,7 +208,7 @@ export class MessageDispatcher {
       });
     });
 
-    console.debug("[MessageDispatcher] action", action);
+    logger.debug("[MessageDispatcher] action", action);
 
     if (this._client.connected) {
       // Send message to transport when connected
@@ -252,19 +253,19 @@ export class MessageDispatcher {
 
     if (queuedMessage) {
       if (resolve) {
-        console.debug("[MessageDispatcher] Resolve", message);
+        logger.debug("[MessageDispatcher] Resolve", message);
         queuedMessage.resolve(
           message.type === RTVIMessageType.ACTION_RESPONSE
             ? (message as RTVIMessageActionResponse)
             : (message as RTVIMessage)
         );
       } else {
-        console.debug("[MessageDispatcher] Reject", message);
+        logger.debug("[MessageDispatcher] Reject", message);
         queuedMessage.reject(message as RTVIMessage);
       }
       // Remove message from queue
       this._queue = this._queue.filter((msg) => msg.message.id !== message.id);
-      console.debug("[MessageDispatcher] Queue", this._queue);
+      logger.debug("[MessageDispatcher] Queue", this._queue);
     }
 
     return message;
@@ -282,7 +283,7 @@ export class MessageDispatcher {
     this._queue = this._queue.filter((msg) => {
       return Date.now() - msg.timestamp < this._gcTime;
     });
-    console.debug("[MessageDispatcher] GC", this._queue);
+    logger.debug("[MessageDispatcher] GC", this._queue);
   }
 }
 

--- a/rtvi-client-react/package.json
+++ b/rtvi-client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realtime-ai-react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
   "module": "dist/index.module.js",


### PR DESCRIPTION
Implemented package-wide logger so that custom log levels can be set for RTVI (without relying on global console log levels)

```typescript
import {logger, LogLevel} from "realtime-ai"

logger.setLevel(LogLevel.DEBUG); // default
logger.setLevel(LogLevel.INFO);
logger.setLevel(LogLevel.WARN);
logger.setLevel(LogLevel.ERROR);
logger.setLevel(LogLevel.NONE);
```

Alternatively, set on the client object itself:

```typescript
rtviClient.setLogLevel(LogLevel.NONE);
```