### PR TITLE
Add jotaiStore prop to RTVIClientProvider

### DIFF
--- a/rtvi-client-react/src/RTVIClientProvider.tsx
+++ b/rtvi-client-react/src/RTVIClientProvider.tsx
@@ -2,19 +2,24 @@ import { createContext } from "react";
 
 import { RTVIClient } from "realtime-ai";
 import { Provider as JotaiProvider } from "jotai/react";
+import { createStore } from "jotai";
 
 export interface Props {
   client: RTVIClient;
+  jotaiStore?: React.ComponentProps<typeof JotaiProvider>["store"];
 }
+
+const defaultStore = createStore();
 
 export const RTVIClientContext = createContext<{ client?: RTVIClient }>({});
 
 export const RTVIClientProvider: React.FC<React.PropsWithChildren<Props>> = ({
   children,
   client,
+  jotaiStore = defaultStore,
 }) => {
   return (
-    <JotaiProvider>
+    <JotaiProvider store={jotaiStore}>
       <RTVIClientContext.Provider value={{ client }}>
         {children}
       </RTVIClientContext.Provider>


### PR DESCRIPTION
This is required for applications using Jotai. Otherwise there's a possibility that state updates are choked when their Jotai provider lives outside of the RTVIClientProvider.